### PR TITLE
V21.11

### DIFF
--- a/Demos/ASP.NET Core/src/GroupDocs.Viewer.AspNetCore.csproj
+++ b/Demos/ASP.NET Core/src/GroupDocs.Viewer.AspNetCore.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GroupDocs.Viewer.UI" Version="3.1.3" />
-    <PackageReference Include="GroupDocs.Viewer.UI.Api.Local.Cache" Version="3.1.2" />
-    <PackageReference Include="GroupDocs.Viewer.UI.Api.Local.Storage" Version="3.1.1" />
-    <PackageReference Include="GroupDocs.Viewer.UI.SelfHost.Api" Version="3.1.7" />
+    <PackageReference Include="GroupDocs.Viewer.UI" Version="3.1.4" />
+    <PackageReference Include="GroupDocs.Viewer.UI.Api.Local.Cache" Version="3.1.3" />
+    <PackageReference Include="GroupDocs.Viewer.UI.Api.Local.Storage" Version="3.1.2" />
+    <PackageReference Include="GroupDocs.Viewer.UI.SelfHost.Api" Version="3.1.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Demos/MVC/src/GroupDocs.Viewer.MVC.csproj
+++ b/Demos/MVC/src/GroupDocs.Viewer.MVC.csproj
@@ -45,8 +45,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="GroupDocs.Viewer, Version=21.10.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
-      <HintPath>..\packages\GroupDocs.Viewer.21.10.0\lib\net40\GroupDocs.Viewer.dll</HintPath>
+    <Reference Include="GroupDocs.Viewer, Version=21.11.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
+      <HintPath>..\packages\GroupDocs.Viewer.21.11.0\lib\net40\GroupDocs.Viewer.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.0\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>

--- a/Demos/MVC/src/Web.config
+++ b/Demos/MVC/src/Web.config
@@ -105,7 +105,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Aspose.CAD" publicKeyToken="716fcc553a201e56" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-21.9.0.0" newVersion="21.9.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-21.10.0.0" newVersion="21.10.0.0" />
         <publisherPolicy apply="no" />
       </dependentAssembly>
       <dependentAssembly>
@@ -135,7 +135,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Aspose.PDF" publicKeyToken="716fcc553a201e56" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-21.9.0.0" newVersion="21.9.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-21.11.0.0" newVersion="21.11.0.0" />
         <publisherPolicy apply="no" />
       </dependentAssembly>
       <dependentAssembly>
@@ -150,7 +150,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Aspose.Words" publicKeyToken="716fcc553a201e56" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-21.7.0.0" newVersion="21.7.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-21.11.0.0" newVersion="21.11.0.0" />
         <publisherPolicy apply="no" />
       </dependentAssembly>
       <dependentAssembly>
@@ -161,6 +161,11 @@
       <dependentAssembly>
         <assemblyIdentity name="Aspose.PSD" publicKeyToken="716fcc553a201e56" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-21.8.0.0" newVersion="21.8.0.0" />
+        <publisherPolicy apply="no" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Aspose.BarCode" publicKeyToken="716fcc553a201e56" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-21.10.0.0" newVersion="21.10.0.0" />
         <publisherPolicy apply="no" />
       </dependentAssembly>
     </assemblyBinding>

--- a/Demos/MVC/src/packages.config
+++ b/Demos/MVC/src/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.4.1.9004" targetFramework="net45" />
-  <package id="GroupDocs.Viewer" version="21.10.0" targetFramework="net45" />
+  <package id="GroupDocs.Viewer" version="21.11.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Cors" version="5.2.5" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net45" />

--- a/Demos/MVC/tests/GroupDocs.Viewer.MVC.Test/GroupDocs.Viewer.MVC.Test.csproj
+++ b/Demos/MVC/tests/GroupDocs.Viewer.MVC.Test/GroupDocs.Viewer.MVC.Test.csproj
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\NUnit3TestAdapter.3.11.2\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.11.2\build\net35\NUnit3TestAdapter.props')" />
-  <Import Project="..\packages\NUnit.3.11.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.11.0\build\NUnit.props')" />
+  <Import Project="..\packages\NUnit.3.13.2\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.13.2\build\NUnit.props')" />
+  <Import Project="..\..\packages\NUnit3TestAdapter.3.11.2\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.11.2\build\net35\NUnit3TestAdapter.props')" />
+  <Import Project="..\..\packages\NUnit.3.11.0\build\NUnit.props" Condition="Exists('..\..\packages\NUnit.3.11.0\build\NUnit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -36,73 +37,74 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Antlr3.Runtime, Version=3.4.1.9004, Culture=neutral, PublicKeyToken=eb42632606e9261f, processorArchitecture=MSIL">
-      <HintPath>..\packages\Antlr.3.4.1.9004\lib\Antlr3.Runtime.dll</HintPath>
+      <HintPath>..\..\packages\Antlr.3.4.1.9004\lib\Antlr3.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
+      <HintPath>..\..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
     <Reference Include="GroupDocs.Viewer, Version=21.10.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
-      <HintPath>..\packages\GroupDocs.Viewer.21.10.0\lib\net40\GroupDocs.Viewer.dll</HintPath>
+      <HintPath>..\..\packages\GroupDocs.Viewer.21.10.0\lib\net40\GroupDocs.Viewer.dll</HintPath>
     </Reference>
     <Reference Include="Huygens, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Huygens.1.4.5\lib\net46\Huygens.dll</HintPath>
+      <HintPath>..\..\packages\Huygens.1.4.5\lib\net46\Huygens.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.Mvc, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mvc2Futures.2.0.50217.0\lib\Microsoft.Web.Mvc.dll</HintPath>
+      <HintPath>..\..\packages\Mvc2Futures.2.0.50217.0\lib\Microsoft.Web.Mvc.dll</HintPath>
     </Reference>
     <Reference Include="Moq, Version=4.10.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\packages\Moq.4.10.1\lib\net45\Moq.dll</HintPath>
+      <HintPath>..\..\packages\Moq.4.10.1\lib\net45\Moq.dll</HintPath>
     </Reference>
     <Reference Include="MvcContrib.TestHelper">
       <HintPath>.\MvcContrib.TestHelper.dll</HintPath>
     </Reference>
     <Reference Include="MvcRouteTester, Version=1.0.1.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MvcRouteTester.1.2.1\lib\net40\MvcRouteTester.dll</HintPath>
+      <HintPath>..\..\packages\MvcRouteTester.1.2.1\lib\net40\MvcRouteTester.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.5.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.5.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.11.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.11.0\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.13.2.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.13.2\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.4.5.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.1\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
+      <HintPath>..\..\packages\System.Threading.Tasks.Extensions.4.5.1\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.ValueTuple.4.4.0\lib\net461\System.ValueTuple.dll</HintPath>
+      <HintPath>..\..\packages\System.ValueTuple.4.4.0\lib\net461\System.ValueTuple.dll</HintPath>
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.7\lib\net45\System.Web.Helpers.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.2.7\lib\net45\System.Web.Helpers.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Mvc, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.Mvc.5.2.3\lib\net45\System.Web.Mvc.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.Mvc.5.2.3\lib\net45\System.Web.Mvc.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Optimization, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.Web.Optimization.1.1.3\lib\net40\System.Web.Optimization.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.Web.Optimization.1.1.3\lib\net40\System.Web.Optimization.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.Razor.3.2.7\lib\net45\System.Web.Razor.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.Razor.3.2.7\lib\net45\System.Web.Razor.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.WebPages, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.7\lib\net45\System.Web.WebPages.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.2.7\lib\net45\System.Web.WebPages.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.WebPages.Deployment, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.7\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.2.7\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.7\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.2.7\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -111,7 +113,7 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="WebGrease, Version=1.6.5135.21930, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\WebGrease.1.6.0\lib\WebGrease.dll</HintPath>
+      <HintPath>..\..\packages\WebGrease.1.6.0\lib\WebGrease.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -136,8 +138,9 @@
     <PropertyGroup>
       <ErrorText>Данный проект ссылается на пакеты NuGet, отсутствующие на этом компьютере. Используйте восстановление пакетов NuGet, чтобы скачать их.  Дополнительную информацию см. по адресу: http://go.microsoft.com/fwlink/?LinkID=322105. Отсутствует следующий файл: {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\NUnit.3.11.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.11.0\build\NUnit.props'))" />
-    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.11.2\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.11.2\build\net35\NUnit3TestAdapter.props'))" />
+    <Error Condition="!Exists('..\..\packages\NUnit.3.11.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NUnit.3.11.0\build\NUnit.props'))" />
+    <Error Condition="!Exists('..\..\packages\NUnit3TestAdapter.3.11.2\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NUnit3TestAdapter.3.11.2\build\net35\NUnit3TestAdapter.props'))" />
+    <Error Condition="!Exists('..\..\packages\NUnit.3.13.2\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NUnit.3.13.2\build\NUnit.props'))" />
   </Target>
   <PropertyGroup>
     <PostBuildEvent>

--- a/Demos/MVC/tests/GroupDocs.Viewer.MVC.Test/ViewerControllerTest.cs
+++ b/Demos/MVC/tests/GroupDocs.Viewer.MVC.Test/ViewerControllerTest.cs
@@ -28,7 +28,7 @@ namespace GroupDocs.Viewer.MVC.Test
         [Test]
         public void ViewStatusTest()
         {
-            string path = AppDomain.CurrentDomain.BaseDirectory + "/../../../src";            
+            string path = AppDomain.CurrentDomain.BaseDirectory + "/../../../../src";            
             using (var server = new DirectServer(path))
             {
                 var request = new SerialisableRequest
@@ -52,7 +52,7 @@ namespace GroupDocs.Viewer.MVC.Test
         [Test]
         public void FileTreeStatusCodeTest()
         {
-            string path = AppDomain.CurrentDomain.BaseDirectory + "/../../../src";
+            string path = AppDomain.CurrentDomain.BaseDirectory + "/../../../../src";
             using (var server = new DirectServer(path))
             {
                 var request = new SerialisableRequest

--- a/Demos/MVC/tests/GroupDocs.Viewer.MVC.Test/app.config
+++ b/Demos/MVC/tests/GroupDocs.Viewer.MVC.Test/app.config
@@ -20,7 +20,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.5.0.0" newVersion="4.5.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
@@ -32,7 +32,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.6.5135.21930" newVersion="1.6.5135.21930" />
+        <bindingRedirect oldVersion="0.0.0.0-1.5.2.14234" newVersion="1.5.2.14234" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/Demos/WPF/src/GroupDocs.Viewer.WPF.csproj
+++ b/Demos/WPF/src/GroupDocs.Viewer.WPF.csproj
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GroupDocs.Viewer" Version="21.10.0" />
+    <PackageReference Include="GroupDocs.Viewer" Version="21.11.0" />
   </ItemGroup>
 
 </Project>

--- a/Demos/WebForms/src/GroupDocs.Viewer.WebForms.csproj
+++ b/Demos/WebForms/src/GroupDocs.Viewer.WebForms.csproj
@@ -44,8 +44,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="GroupDocs.Viewer, Version=21.10.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
-      <HintPath>..\packages\GroupDocs.Viewer.21.10.0\lib\net40\GroupDocs.Viewer.dll</HintPath>
+    <Reference Include="GroupDocs.Viewer, Version=21.11.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
+      <HintPath>..\packages\GroupDocs.Viewer.21.11.0\lib\net40\GroupDocs.Viewer.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.0\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>

--- a/Demos/WebForms/src/Web.config
+++ b/Demos/WebForms/src/Web.config
@@ -133,7 +133,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Aspose.CAD" publicKeyToken="716fcc553a201e56" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-21.9.0.0" newVersion="21.9.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-21.10.0.0" newVersion="21.10.0.0" />
         <publisherPolicy apply="no" />
       </dependentAssembly>
       <dependentAssembly>
@@ -163,7 +163,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Aspose.PDF" publicKeyToken="716fcc553a201e56" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-21.9.0.0" newVersion="21.9.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-21.11.0.0" newVersion="21.11.0.0" />
         <publisherPolicy apply="no" />
       </dependentAssembly>
       <dependentAssembly>
@@ -178,7 +178,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Aspose.Words" publicKeyToken="716fcc553a201e56" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-21.7.0.0" newVersion="21.7.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-21.11.0.0" newVersion="21.11.0.0" />
         <publisherPolicy apply="no" />
       </dependentAssembly>
       <dependentAssembly>
@@ -189,6 +189,11 @@
       <dependentAssembly>
         <assemblyIdentity name="Aspose.PSD" publicKeyToken="716fcc553a201e56" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-21.8.0.0" newVersion="21.8.0.0" />
+        <publisherPolicy apply="no" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Aspose.BarCode" publicKeyToken="716fcc553a201e56" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-21.10.0.0" newVersion="21.10.0.0" />
         <publisherPolicy apply="no" />
       </dependentAssembly>
     </assemblyBinding>

--- a/Demos/WebForms/src/packages.config
+++ b/Demos/WebForms/src/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.4.1.9004" targetFramework="net45" />
-  <package id="GroupDocs.Viewer" version="21.10.0" targetFramework="net45" />
+  <package id="GroupDocs.Viewer" version="21.11.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Cors" version="5.2.6" targetFramework="net45" />
   <package id="Microsoft.AspNet.FriendlyUrls" version="1.0.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.FriendlyUrls.Core" version="1.0.2" targetFramework="net45" />

--- a/Demos/WinForms/src/GroupDocs.Viewer.WinForms/App.config
+++ b/Demos/WinForms/src/GroupDocs.Viewer.WinForms/App.config
@@ -7,7 +7,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Aspose.CAD" publicKeyToken="716fcc553a201e56" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-21.9.0.0" newVersion="21.9.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-21.10.0.0" newVersion="21.10.0.0" />
         <publisherPolicy apply="no" />
       </dependentAssembly>
       <dependentAssembly>
@@ -37,7 +37,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Aspose.PDF" publicKeyToken="716fcc553a201e56" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-21.9.0.0" newVersion="21.9.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-21.11.0.0" newVersion="21.11.0.0" />
         <publisherPolicy apply="no" />
       </dependentAssembly>
       <dependentAssembly>
@@ -52,7 +52,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Aspose.Words" publicKeyToken="716fcc553a201e56" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-21.7.0.0" newVersion="21.7.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-21.11.0.0" newVersion="21.11.0.0" />
         <publisherPolicy apply="no" />
       </dependentAssembly>
       <dependentAssembly>
@@ -63,6 +63,11 @@
       <dependentAssembly>
         <assemblyIdentity name="Aspose.PSD" publicKeyToken="716fcc553a201e56" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-21.8.0.0" newVersion="21.8.0.0" />
+        <publisherPolicy apply="no" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Aspose.BarCode" publicKeyToken="716fcc553a201e56" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-21.10.0.0" newVersion="21.10.0.0" />
         <publisherPolicy apply="no" />
       </dependentAssembly>
     </assemblyBinding>

--- a/Demos/WinForms/src/GroupDocs.Viewer.WinForms/GroupDocs.Viewer.WinForms.csproj
+++ b/Demos/WinForms/src/GroupDocs.Viewer.WinForms/GroupDocs.Viewer.WinForms.csproj
@@ -33,8 +33,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="GroupDocs.Viewer, Version=21.10.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
-      <HintPath>..\packages\GroupDocs.Viewer.21.10.0\lib\net40\GroupDocs.Viewer.dll</HintPath>
+    <Reference Include="GroupDocs.Viewer, Version=21.11.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
+      <HintPath>..\packages\GroupDocs.Viewer.21.11.0\lib\net40\GroupDocs.Viewer.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Demos/WinForms/src/GroupDocs.Viewer.WinForms/packages.config
+++ b/Demos/WinForms/src/GroupDocs.Viewer.WinForms/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="GroupDocs.Viewer" version="21.10.0" targetFramework="net461" />
+  <package id="GroupDocs.Viewer" version="21.11.0" targetFramework="net461" />
 </packages>

--- a/Examples/GroupDocs.Viewer.Examples.CSharp.Core/GroupDocs.Viewer.Examples.CSharp.Core.csproj
+++ b/Examples/GroupDocs.Viewer.Examples.CSharp.Core/GroupDocs.Viewer.Examples.CSharp.Core.csproj
@@ -8,7 +8,7 @@
   <Import Project="..\GroupDocs.Viewer.Examples.CSharp\GroupDocs.Viewer.Examples.CSharp.projitems" Label="Shared" />
 
   <ItemGroup>
-    <PackageReference Include="GroupDocs.Viewer" Version="21.10.0" />
+    <PackageReference Include="GroupDocs.Viewer" Version="21.11.0" />
   </ItemGroup>
 
 </Project>

--- a/Examples/GroupDocs.Viewer.Examples.CSharp.Framework/App.config
+++ b/Examples/GroupDocs.Viewer.Examples.CSharp.Framework/App.config
@@ -35,7 +35,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Aspose.CAD" publicKeyToken="716fcc553a201e56" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-21.9.0.0" newVersion="21.9.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-21.10.0.0" newVersion="21.10.0.0" />
         <publisherPolicy apply="no" />
       </dependentAssembly>
       <dependentAssembly>
@@ -65,7 +65,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Aspose.PDF" publicKeyToken="716fcc553a201e56" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-21.9.0.0" newVersion="21.9.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-21.11.0.0" newVersion="21.11.0.0" />
         <publisherPolicy apply="no" />
       </dependentAssembly>
       <dependentAssembly>
@@ -80,7 +80,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Aspose.Words" publicKeyToken="716fcc553a201e56" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-21.7.0.0" newVersion="21.7.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-21.11.0.0" newVersion="21.11.0.0" />
         <publisherPolicy apply="no" />
       </dependentAssembly>
       <dependentAssembly>
@@ -91,6 +91,11 @@
       <dependentAssembly>
         <assemblyIdentity name="Aspose.PSD" publicKeyToken="716fcc553a201e56" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-21.8.0.0" newVersion="21.8.0.0" />
+        <publisherPolicy apply="no" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Aspose.BarCode" publicKeyToken="716fcc553a201e56" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-21.10.0.0" newVersion="21.10.0.0" />
         <publisherPolicy apply="no" />
       </dependentAssembly>
     </assemblyBinding>

--- a/Examples/GroupDocs.Viewer.Examples.CSharp.Framework/GroupDocs.Viewer.Examples.CSharp.Framework.csproj
+++ b/Examples/GroupDocs.Viewer.Examples.CSharp.Framework/GroupDocs.Viewer.Examples.CSharp.Framework.csproj
@@ -47,8 +47,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="GroupDocs.Viewer, Version=21.10.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
-      <HintPath>..\packages\GroupDocs.Viewer.21.10.0\lib\net40\GroupDocs.Viewer.dll</HintPath>
+    <Reference Include="GroupDocs.Viewer, Version=21.11.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
+      <HintPath>..\packages\GroupDocs.Viewer.21.11.0\lib\net40\GroupDocs.Viewer.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.1.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>

--- a/Examples/GroupDocs.Viewer.Examples.CSharp.Framework/packages.config
+++ b/Examples/GroupDocs.Viewer.Examples.CSharp.Framework/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="GroupDocs.Viewer" version="21.10.0" targetFramework="net48" />
+  <package id="GroupDocs.Viewer" version="21.11.0" targetFramework="net48" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="1.0.0" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net472" />
   <package id="Pipelines.Sockets.Unofficial" version="2.0.22" targetFramework="net472" />


### PR DESCRIPTION
Updated GroupDocs.Viewer for .NET to 21.11.
Release notes: https://docs.groupdocs.com/viewer/net/groupdocs-viewer-for-net-21-11-release-notes/