### PR TITLE
Update GroupDocs.Viewer references up to 23.6 version

### DIFF
--- a/Demos/ASP.NET Core/src/GroupDocs.Viewer.AspNetCore.csproj
+++ b/Demos/ASP.NET Core/src/GroupDocs.Viewer.AspNetCore.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GroupDocs.Viewer.UI" Version="6.0.10" />
+    <PackageReference Include="GroupDocs.Viewer.UI" Version="6.0.11" />
     <PackageReference Include="GroupDocs.Viewer.UI.Api.Local.Cache" Version="6.0.0" />
     <PackageReference Include="GroupDocs.Viewer.UI.Api.Local.Storage" Version="6.0.0" />
-    <PackageReference Include="GroupDocs.Viewer.UI.SelfHost.Api" Version="6.0.11" />
+    <PackageReference Include="GroupDocs.Viewer.UI.SelfHost.Api" Version="6.0.13" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Demos/ASP.NET MVC/src/GroupDocs.Viewer.AspNetMvc.csproj
+++ b/Demos/ASP.NET MVC/src/GroupDocs.Viewer.AspNetMvc.csproj
@@ -49,8 +49,8 @@
     <Reference Include="AsyncKeyedLock, Version=6.2.1.0, Culture=neutral, PublicKeyToken=c6dde91429ba0f2f, processorArchitecture=MSIL">
       <HintPath>packages\AsyncKeyedLock.6.2.1\lib\netstandard2.0\AsyncKeyedLock.dll</HintPath>
     </Reference>
-    <Reference Include="GroupDocs.Viewer, Version=23.4.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
-      <HintPath>packages\GroupDocs.Viewer.23.4.0\lib\net40\GroupDocs.Viewer.dll</HintPath>
+    <Reference Include="GroupDocs.Viewer, Version=23.6.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
+      <HintPath>packages\GroupDocs.Viewer.23.6.0\lib\net40\GroupDocs.Viewer.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=3.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.3.6.0\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>

--- a/Demos/ASP.NET MVC/src/Web.config
+++ b/Demos/ASP.NET MVC/src/Web.config
@@ -62,6 +62,11 @@
         <publisherPolicy apply="no" />
       </dependentAssembly>
       <dependentAssembly>
+        <assemblyIdentity name="Aspose.Words.Shaping.HarfBuzz" publicKeyToken="716fcc553a201e56" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-23.3.0.0" newVersion="23.3.0.0" />
+        <publisherPolicy apply="no" />
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="Aspose.CAD" publicKeyToken="716fcc553a201e56" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-22.7.0.0" newVersion="22.7.0.0" />
         <publisherPolicy apply="no" />
@@ -93,7 +98,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Aspose.PDF" publicKeyToken="716fcc553a201e56" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-23.3.0.0" newVersion="23.3.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-23.6.0.0" newVersion="23.6.0.0" />
         <publisherPolicy apply="no" />
       </dependentAssembly>
       <dependentAssembly>
@@ -108,12 +113,12 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Aspose.Words" publicKeyToken="716fcc553a201e56" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-23.3.0.0" newVersion="23.3.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-23.6.0.0" newVersion="23.6.0.0" />
         <publisherPolicy apply="no" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Aspose.Words.Shaping.HarfBuzz" publicKeyToken="716fcc553a201e56" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-23.3.0.0" newVersion="23.3.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-23.6.0.0" newVersion="23.6.0.0" />
         <publisherPolicy apply="no" />
       </dependentAssembly>
       <dependentAssembly>

--- a/Demos/ASP.NET MVC/src/packages.config
+++ b/Demos/ASP.NET MVC/src/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AsyncKeyedLock" version="6.2.1" targetFramework="net48" />
-  <package id="GroupDocs.Viewer" version="23.4.0" targetFramework="net48" />
+  <package id="GroupDocs.Viewer" version="23.6.0" targetFramework="net48" />
   <package id="Microsoft.AspNet.Cors" version="5.2.9" targetFramework="net48" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.9" targetFramework="net48" />
   <package id="Microsoft.AspNet.Razor" version="3.2.9" targetFramework="net48" />

--- a/Demos/ASP.NET Web Forms/src/GroupDocs.Viewer.AspNetWebForms.csproj
+++ b/Demos/ASP.NET Web Forms/src/GroupDocs.Viewer.AspNetWebForms.csproj
@@ -48,8 +48,8 @@
     <Reference Include="AsyncKeyedLock, Version=6.2.1.0, Culture=neutral, PublicKeyToken=c6dde91429ba0f2f, processorArchitecture=MSIL">
       <HintPath>packages\AsyncKeyedLock.6.2.1\lib\netstandard2.0\AsyncKeyedLock.dll</HintPath>
     </Reference>
-    <Reference Include="GroupDocs.Viewer, Version=23.4.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
-      <HintPath>packages\GroupDocs.Viewer.23.4.0\lib\net40\GroupDocs.Viewer.dll</HintPath>
+    <Reference Include="GroupDocs.Viewer, Version=23.6.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
+      <HintPath>packages\GroupDocs.Viewer.23.6.0\lib\net40\GroupDocs.Viewer.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=3.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.3.6.0\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>

--- a/Demos/ASP.NET Web Forms/src/Web.config
+++ b/Demos/ASP.NET Web Forms/src/Web.config
@@ -53,6 +53,11 @@
         <publisherPolicy apply="no" />
       </dependentAssembly>
       <dependentAssembly>
+        <assemblyIdentity name="Aspose.Words.Shaping.HarfBuzz" publicKeyToken="716fcc553a201e56" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-23.3.0.0" newVersion="23.3.0.0" />
+        <publisherPolicy apply="no" />
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="Aspose.CAD" publicKeyToken="716fcc553a201e56" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-22.7.0.0" newVersion="22.7.0.0" />
         <publisherPolicy apply="no" />
@@ -84,7 +89,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Aspose.PDF" publicKeyToken="716fcc553a201e56" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-23.3.0.0" newVersion="23.3.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-23.6.0.0" newVersion="23.6.0.0" />
         <publisherPolicy apply="no" />
       </dependentAssembly>
       <dependentAssembly>
@@ -99,12 +104,12 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Aspose.Words" publicKeyToken="716fcc553a201e56" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-23.3.0.0" newVersion="23.3.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-23.6.0.0" newVersion="23.6.0.0" />
         <publisherPolicy apply="no" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Aspose.Words.Shaping.HarfBuzz" publicKeyToken="716fcc553a201e56" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-23.3.0.0" newVersion="23.3.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-23.6.0.0" newVersion="23.6.0.0" />
         <publisherPolicy apply="no" />
       </dependentAssembly>
       <dependentAssembly>

--- a/Demos/ASP.NET Web Forms/src/packages.config
+++ b/Demos/ASP.NET Web Forms/src/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AsyncKeyedLock" version="6.2.1" targetFramework="net48" />
-  <package id="GroupDocs.Viewer" version="23.4.0" targetFramework="net48" />
+  <package id="GroupDocs.Viewer" version="23.6.0" targetFramework="net48" />
   <package id="Microsoft.AspNet.Cors" version="5.2.9" targetFramework="net48" />
   <package id="Microsoft.AspNet.WebApi" version="5.2.9" targetFramework="net48" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.9" targetFramework="net48" />

--- a/Demos/WPF/src/GroupDocs.Viewer.WPF.csproj
+++ b/Demos/WPF/src/GroupDocs.Viewer.WPF.csproj
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GroupDocs.Viewer" Version="23.4.0" />
+    <PackageReference Include="GroupDocs.Viewer" Version="23.6.0" />
   </ItemGroup>
 
 </Project>

--- a/Demos/Windows Forms/src/App.config
+++ b/Demos/Windows Forms/src/App.config
@@ -11,6 +11,11 @@
         <publisherPolicy apply="no" />
       </dependentAssembly>
       <dependentAssembly>
+        <assemblyIdentity name="Aspose.Words.Shaping.HarfBuzz" publicKeyToken="716fcc553a201e56" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-23.3.0.0" newVersion="23.3.0.0" />
+        <publisherPolicy apply="no" />
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="Aspose.CAD" publicKeyToken="716fcc553a201e56" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-22.7.0.0" newVersion="22.7.0.0" />
         <publisherPolicy apply="no" />
@@ -42,7 +47,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Aspose.PDF" publicKeyToken="716fcc553a201e56" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-23.3.0.0" newVersion="23.3.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-23.6.0.0" newVersion="23.6.0.0" />
         <publisherPolicy apply="no" />
       </dependentAssembly>
       <dependentAssembly>
@@ -57,12 +62,12 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Aspose.Words" publicKeyToken="716fcc553a201e56" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-23.3.0.0" newVersion="23.3.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-23.6.0.0" newVersion="23.6.0.0" />
         <publisherPolicy apply="no" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Aspose.Words.Shaping.HarfBuzz" publicKeyToken="716fcc553a201e56" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-23.3.0.0" newVersion="23.3.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-23.6.0.0" newVersion="23.6.0.0" />
         <publisherPolicy apply="no" />
       </dependentAssembly>
       <dependentAssembly>

--- a/Demos/Windows Forms/src/GroupDocs.Viewer.WinForms.csproj
+++ b/Demos/Windows Forms/src/GroupDocs.Viewer.WinForms.csproj
@@ -34,8 +34,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="GroupDocs.Viewer, Version=23.4.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
-      <HintPath>packages\GroupDocs.Viewer.23.4.0\lib\net40\GroupDocs.Viewer.dll</HintPath>
+    <Reference Include="GroupDocs.Viewer, Version=23.6.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
+      <HintPath>packages\GroupDocs.Viewer.23.6.0\lib\net40\GroupDocs.Viewer.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Demos/Windows Forms/src/packages.config
+++ b/Demos/Windows Forms/src/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="GroupDocs.Viewer" version="23.4.0" targetFramework="net48" />
+  <package id="GroupDocs.Viewer" version="23.6.0" targetFramework="net48" />
 </packages>

--- a/Examples/GroupDocs.Viewer.Examples.CSharp.Core/GroupDocs.Viewer.Examples.CSharp.Core.csproj
+++ b/Examples/GroupDocs.Viewer.Examples.CSharp.Core/GroupDocs.Viewer.Examples.CSharp.Core.csproj
@@ -9,7 +9,7 @@
   <Import Project="..\GroupDocs.Viewer.Examples.CSharp\GroupDocs.Viewer.Examples.CSharp.projitems" Label="Shared" />
 
   <ItemGroup>
-    <PackageReference Include="GroupDocs.Viewer" Version="23.4.0" />
+    <PackageReference Include="GroupDocs.Viewer" Version="23.6.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.18.1" />
   </ItemGroup>
 

--- a/Examples/GroupDocs.Viewer.Examples.CSharp.Framework/App.config
+++ b/Examples/GroupDocs.Viewer.Examples.CSharp.Framework/App.config
@@ -39,6 +39,11 @@
         <publisherPolicy apply="no" />
       </dependentAssembly>
       <dependentAssembly>
+        <assemblyIdentity name="Aspose.Words.Shaping.HarfBuzz" publicKeyToken="716fcc553a201e56" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-23.3.0.0" newVersion="23.3.0.0" />
+        <publisherPolicy apply="no" />
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="Aspose.CAD" publicKeyToken="716fcc553a201e56" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-22.7.0.0" newVersion="22.7.0.0" />
         <publisherPolicy apply="no" />
@@ -70,7 +75,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Aspose.PDF" publicKeyToken="716fcc553a201e56" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-23.3.0.0" newVersion="23.3.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-23.6.0.0" newVersion="23.6.0.0" />
         <publisherPolicy apply="no" />
       </dependentAssembly>
       <dependentAssembly>
@@ -85,12 +90,12 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Aspose.Words" publicKeyToken="716fcc553a201e56" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-23.3.0.0" newVersion="23.3.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-23.6.0.0" newVersion="23.6.0.0" />
         <publisherPolicy apply="no" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Aspose.Words.Shaping.HarfBuzz" publicKeyToken="716fcc553a201e56" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-23.3.0.0" newVersion="23.3.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-23.6.0.0" newVersion="23.6.0.0" />
         <publisherPolicy apply="no" />
       </dependentAssembly>
       <dependentAssembly>

--- a/Examples/GroupDocs.Viewer.Examples.CSharp.Framework/GroupDocs.Viewer.Examples.CSharp.Framework.csproj
+++ b/Examples/GroupDocs.Viewer.Examples.CSharp.Framework/GroupDocs.Viewer.Examples.CSharp.Framework.csproj
@@ -47,8 +47,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="GroupDocs.Viewer, Version=23.4.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
-      <HintPath>..\packages\GroupDocs.Viewer.23.4.0\lib\net40\GroupDocs.Viewer.dll</HintPath>
+    <Reference Include="GroupDocs.Viewer, Version=23.6.0.0, Culture=neutral, PublicKeyToken=716fcc553a201e56, processorArchitecture=MSIL">
+      <HintPath>..\packages\GroupDocs.Viewer.23.6.0\lib\net40\GroupDocs.Viewer.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />

--- a/Examples/GroupDocs.Viewer.Examples.CSharp.Framework/packages.config
+++ b/Examples/GroupDocs.Viewer.Examples.CSharp.Framework/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="GroupDocs.Viewer" version="23.4.0" targetFramework="net48" />
+  <package id="GroupDocs.Viewer" version="23.6.0" targetFramework="net48" />
 </packages>

--- a/Examples/GroupDocs.Viewer.Examples.CSharp.NET6/GroupDocs.Viewer.Examples.CSharp.NET6.csproj
+++ b/Examples/GroupDocs.Viewer.Examples.CSharp.NET6/GroupDocs.Viewer.Examples.CSharp.NET6.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GroupDocs.Viewer" Version="23.4.0" />
+    <PackageReference Include="GroupDocs.Viewer" Version="23.6.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.18.1" />
   </ItemGroup>
 


### PR DESCRIPTION
https://releases.groupdocs.com/viewer/net/release-notes/2023/groupdocs-viewer-for-net-23-6-release-notes/